### PR TITLE
add the ability to restore a spied function on an object

### DIFF
--- a/modules/__tests__/spy-test.js
+++ b/modules/__tests__/spy-test.js
@@ -50,6 +50,12 @@ describe('A function that was spied on using spyOn', function () {
   it('was called with the correct args', function () {
     expect(spy).toHaveBeenCalledWith('some', 'args');
   });
+
+  it('can be restored', function () {
+    expect(video.play).toEqual(spy);
+    spy.restore();
+    expect(video.play).toNotEqual(spy);
+  });
 });
 
 describe('A spy', function () {

--- a/modules/index.js
+++ b/modules/index.js
@@ -262,13 +262,20 @@ function createSpy(fn) {
 Expectation.spyOn = spyOn;
 
 function spyOn(object, methodName) {
-  expect(object[methodName]).toBeA(
+  var original = object[methodName];
+
+  expect(original).toBeA(
     Function,
     formatString('%s does not have a method named "%s"', inspect(object), methodName)
   );
 
-  if (!object[methodName].__isSpy)
-    object[methodName] = createSpy(object[methodName]);
+  if (!original.__isSpy) {
+    var spy = createSpy(original);
+    spy.restore = function(){
+      object[methodName] = original;
+    };
+    object[methodName] = spy;
+  }
 
   return object[methodName];
 }


### PR DESCRIPTION
First off, thanks for the amazing assertion library.

I ran into a scenario where I needed to restore a spied on function to its original state.  I figured it would be better if it existed in the library instead of in my code.