### PR TITLE
Add ability to specify function context and arguments using `.withContext()` and `.withArgs()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ expect(function () {
 }).toThrow(/boom/);
 ```
 
+##### expect(block).withArgs(arg1[,arg2...]).toThrow([error], [message])
+
+Asserts that the given `block` throws an error, when called `args`, using [assert.throws](http://nodejs.org/api/assert.html#assert_assert_throws_block_error_message). The `error` argument may be a constructor, `RegExp`, or validation function.
+
+```js
+expect(function (check) {
+  if (check === 'bad') {
+    throw new Error('boom!');
+  }
+}).withArgs('bad').toThrow(/boom/);
+```
+
+##### expect(block).withContext(context).toThrow([error], [message])
+
+Asserts that the given `block` throws an error, when called on `context`, using [assert.throws](http://nodejs.org/api/assert.html#assert_assert_throws_block_error_message). The `error` argument may be a constructor, `RegExp`, or validation function.
+
+```js
+expect(function () {
+  if (this.check === 'bad') {
+    throw new Error('boom!');
+  }
+}).withContext({ check: 'bad' }).toThrow(/boom/);
+```
+
 ##### expect(block).toNotThrow([message])
 
 Asserts that the given `block` does not throw using [assert.doesNotThrow](http://nodejs.org/api/assert.html#assert_assert_doesnotthrow_block_message).

--- a/modules/__tests__/with-args-test.js
+++ b/modules/__tests__/with-args-test.js
@@ -1,0 +1,30 @@
+var expect = require('../index');
+
+describe('Expectation#withArgs', function () {
+  var fn = function(arg1, arg2) {
+    if (arg1 === 'first' && typeof arg2 === 'undefined') {
+      throw new Error('first arg found');
+    }
+    if (arg1 === 'first' && arg2 === 'second') {
+      throw new Error('both args found');
+    }
+  };
+
+  it('invokes actual function with args', function () {
+    expect(function () {
+      expect(fn).withArgs('first').toThrow(/first arg found/);
+    }).toNotThrow();
+  });
+
+  it('can be chained', function () {
+    expect(function () {
+      expect(fn).withArgs('first').withArgs('second').toThrow(/both args found/);
+    }).toNotThrow();
+  });
+
+  it('throws when actual is not a function', function () {
+    expect(function () {
+      expect('not a function').withArgs('first').toThrow();
+    }).toThrow(/The actual value used in withArgs must be a function/);
+  });
+});

--- a/modules/__tests__/with-context-test.js
+++ b/modules/__tests__/with-context-test.js
@@ -1,0 +1,34 @@
+var expect = require('../index');
+
+describe('Expectation#withContext', function () {
+  var context = {
+    check: true
+  };
+  var fn = function(arg) {
+    if (this.check && typeof arg === 'undefined') {
+      throw new Error('context found');
+    }
+
+    if (this.check && arg === 'good') {
+      throw new Error('context and args found');
+    }
+  };
+
+  it('calls function with context', function () {
+    expect(function () {
+      expect(fn).withContext(context).toThrow(/context found/);
+    }).toNotThrow();
+  });
+
+  it('calls function with context and args', function () {
+    expect(function () {
+      expect(fn).withContext(context).withArgs('good').toThrow(/context and args found/);
+    }).toNotThrow();
+  });
+
+  it('throws when actual is not a function', function () {
+    expect(function () {
+      expect('not a function').withContext(context).toThrow();
+    }).toThrow(/The actual value used in withContext must be a function/);
+  });
+});


### PR DESCRIPTION
This PR is meant to address issue #2, by adding `.withArgs()`. I also added `.withContext()` because I've also had the need to test functions in a specific context.

Unit tests and docs included.