### PR TITLE
Add node 0.12 to travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"


### PR DESCRIPTION
Make Travis CI run tests against the latest 0.10.x and 0.12.x branch releases