### PR TITLE
Reformat readme to be more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# expect
+
 [![build status](https://img.shields.io/travis/mjackson/expect.svg?style=flat-square)](https://travis-ci.org/mjackson/expect)
 [![npm package](https://img.shields.io/npm/v/expect.svg?style=flat-square)](https://www.npmjs.org/package/expect)
 
@@ -5,7 +7,9 @@
 
 When you use expect, you write assertions similarly to how you would say them, e.g. "I expect this value to be equal to 3" or "I expect this array to contain 3". When you write assertions in this way, you don't need to remember the order of actual and expected arguments to functions like `assert.equal`, which helps you write better tests.
 
-### Installation
+<br>
+
+## Installation
 
 Using [npm](https://www.npmjs.org/):
 
@@ -30,9 +34,13 @@ There is a UMD build in the npm package in the `umd` directory. Use it like:
 var expect = require('expect/umd/expect.min')
 ```
 
-### Assertions
+<br>
 
-##### expect(object).toExist([message])
+## Assertions
+
+### toExist
+
+> `expect(object).toExist([message])`
 
 Asserts the given `object` is truthy.
 
@@ -40,7 +48,9 @@ Asserts the given `object` is truthy.
 expect('something truthy').toExist()
 ```
 
-##### expect(object).toNotExist([message])
+#### toNotExist
+
+> `expect(object).toNotExist([message])`
 
 Asserts the given `object` is falsy.
 
@@ -48,23 +58,33 @@ Asserts the given `object` is falsy.
 expect(null).toNotExist()
 ```
 
-##### expect(object).toBe(value, [message])
+### toBe
+
+> `expect(object).toBe(value, [message])`
 
 Asserts that `object` is strictly equal to `value` using `===`.
 
-##### expect(object).toNotBe(value, [message])
+### toNotBe
+
+> `expect(object).toNotBe(value, [message])`
 
 Asserts that `object` is not strictly equal to `value` using `===`.
 
-##### expect(object).toEqual(value, [message])
+### toEqual
+
+> `expect(object).toEqual(value, [message])`
 
 Asserts that the given `object` equals `value` using [deep-equal](https://www.npmjs.com/package/deep-equal).
 
-##### expect(object).toNotEqual(value, [message])
+### toNotEqual
+
+> `expect(object).toNotEqual(value, [message])`
 
 Asserts that the given `object` is not equal to `value` using [deep-equal](https://www.npmjs.com/package/deep-equal).
 
-##### expect(block).toThrow([error], [message])
+### toThrow
+
+> `expect(block).toThrow([error], [message])`
 
 Asserts that the given `block` `throw`s an error. The `error` argument may be a constructor (to test using `instanceof`), or a string/`RegExp` to test against `error.message`.
 
@@ -74,7 +94,9 @@ expect(function () {
 }).toThrow(/boom/)
 ```
 
-##### expect(block).withArgs(...args).toThrow([error], [message])
+### withArgs
+
+> `expect(block).withArgs(...args).toThrow([error], [message])`
 
 Asserts that the given `block` `throw`s an error when called with `args`. The `error` argument may be a constructor (to test using `instanceof`), or a string/`RegExp` to test against `error.message`.
 
@@ -85,7 +107,9 @@ expect(function (check) {
 }).withArgs('bad').toThrow(/boom/)
 ```
 
-##### expect(block).withContext(context).toThrow([error], [message])
+### withContext
+
+> `expect(block).withContext(context).toThrow([error], [message])`
 
 Asserts that the given `block` `throw`s an error when called in the given `context`. The `error` argument may be a constructor (to test using `instanceof`), or a string/`RegExp` to test against `error.message`.
 
@@ -96,12 +120,16 @@ expect(function () {
 }).withContext({ check: 'bad' }).toThrow(/boom/)
 ```
 
-##### expect(block).toNotThrow([message])
+### toNotThrow
+
+> `expect(block).toNotThrow([message])`
 
 Asserts that the given `block` does not `throw`.
 
-##### expect(object).toBeA(constructor, [message])
-##### expect(object).toBeAn(constructor, [message])
+### toBeA(constructor)
+
+> `expect(object).toBeA(constructor, [message])`<br>
+> `expect(object).toBeAn(constructor, [message])`
 
 Asserts the given `object` is an `instanceof constructor`.
 
@@ -110,7 +138,10 @@ expect(new User).toBeA(User)
 expect(new Asset).toBeAn(Asset)
 ```
 
-##### expect(object).toBeA(string, [message])
+### toBeA(string)
+
+> `expect(object).toBeA(string, [message])`<br>
+> `expect(object).toBeAn(string, [message])`
 
 Asserts the `typeof` the given `object` is `string`.
 
@@ -118,8 +149,10 @@ Asserts the `typeof` the given `object` is `string`.
 expect(2).toBeA('number')
 ```
 
-##### expect(object).toNotBeA(constructor, [message])
-##### expect(object).toNotBeAn(constructor, [message])
+### toNotBeA(constructor)
+
+> `expect(object).toNotBeA(constructor, [message])`<br>
+> `expect(object).toNotBeAn(constructor, [message])`
 
 Asserts the given `object` is *not* an `instanceof constructor`.
 
@@ -128,7 +161,10 @@ expect(new User).toBeA(User)
 expect(new Asset).toBeAn(Asset)
 ```
 
-##### expect(object).toNotBeA(string, [message])
+### toNotBeA(string)
+
+> `expect(object).toNotBeA(string, [message])`<br>
+> `expect(object).toNotBeAn(string, [message])`
 
 Asserts the `typeof` the given `object` is *not* `string`.
 
@@ -136,7 +172,9 @@ Asserts the `typeof` the given `object` is *not* `string`.
 expect(2).toBeA('number')
 ```
 
-##### expect(string).toMatch(pattern, [message])
+### toMatch
+
+> `##### expect(string).toMatch(pattern, [message])`
 
 Asserts the given `string` matches `pattern`, which must be a `RegExp`.
 
@@ -144,8 +182,10 @@ Asserts the given `string` matches `pattern`, which must be a `RegExp`.
 expect('a string').toMatch(/string/)
 ```
 
-##### expect(number).toBeLessThan(value, [message])
-##### expect(number).toBeFewerThan(value, [message])
+### toBeLessThan
+
+> `expect(number).toBeLessThan(value, [message])`<br>
+> `expect(number).toBeFewerThan(value, [message])`
 
 Asserts the given `number` is less than `value`.
 
@@ -153,8 +193,10 @@ Asserts the given `number` is less than `value`.
 expect(2).toBeLessThan(3)
 ```
 
-##### expect(number).toBeGreaterThan(value, [message])
-##### expect(number).toBeMoreThan(value, [message])
+### toBeGreaterThan
+
+> `expect(number).toBeGreaterThan(value, [message])`<br>
+> `expect(number).toBeMoreThan(value, [message])`
 
 Asserts the given `number` is greater than `value`.
 
@@ -162,8 +204,10 @@ Asserts the given `number` is greater than `value`.
 expect(3).toBeGreaterThan(2)
 ```
 
-##### expect(array).toInclude(value, [comparator], [message])
-##### expect(array).toContain(value, [comparator], [message])
+### toInclude
+
+> `expect(array).toInclude(value, [comparator], [message])`<br>
+> `expect(array).toContain(value, [comparator], [message])`
 
 Asserts the given `array` contains `value`. The `comparator` function, if given, should compare two objects and either `return false` or `throw` if they are not equal. It defaults to `assert.deepEqual`.
 
@@ -171,8 +215,10 @@ Asserts the given `array` contains `value`. The `comparator` function, if given,
 expect([ 1, 2, 3 ]).toInclude(3)
 ```
 
-##### expect(array).toExclude(value, [comparator], [message])
-##### expect(array).toNotContain(value, [comparator], [message])
+### toExclude
+
+> `expect(array).toExclude(value, [comparator], [message])`<br>
+> `expect(array).toNotContain(value, [comparator], [message])`
 
 Asserts the given `array` does not contain `value`. The `comparator` function, if given, should compare two objects and either `return false` or `throw` if they are not equal. It defaults to `assert.deepEqual`.
 
@@ -180,8 +226,10 @@ Asserts the given `array` does not contain `value`. The `comparator` function, i
 expect([ 1, 2, 3 ]).toExclude(4)
 ```
 
-##### expect(string).toInclude(value, [message])
-##### expect(string).toContain(value, [message])
+### (string) toInclude
+
+> `expect(string).toInclude(value, [message])`<br>
+> `expect(string).toContain(value, [message])`
 
 Asserts the given `string` contains `value`.
 
@@ -190,8 +238,10 @@ expect('hello world').toInclude('world')
 expect('hello world').toContain('world')
 ```
 
-##### expect(string).toExclude(value, [message])
-##### expect(string).toNotContain(value, [message])
+### (string) toExclude
+
+> `expect(string).toExclude(value, [message])`<br>
+> `expect(string).toNotContain(value, [message])`
 
 Asserts the given `string` does not contain `value`.
 
@@ -200,7 +250,9 @@ expect('hello world').toExclude('goodbye')
 expect('hello world').toNotContain('goodbye')
 ```
 
-### Chaining Assertions
+<br>
+
+## Chaining Assertions
 
 Every assertion returns an `Expectation` object, so you can chain assertions together.
 
@@ -211,7 +263,9 @@ expect(3.14)
   .toBeGreaterThan(3)
 ```
 
-### Spies
+<br>
+
+## Spies
 
 expect also includes the ability to create spy functions that can track the calls that are made to other functions and make various assertions based on the arguments and context that were used.
 
@@ -233,11 +287,13 @@ expect(spy).toHaveBeenCalled()
 expect(spy).toHaveBeenCalledWith('some', 'args')
 ```
 
-### Issues
+<br>
+
+## Issues
 
 Please file issues on the [issue tracker on GitHub](https://github.com/mjackson/expect/issues).
 
-### Tests
+## Tests
 
 To run the tests in node:
 
@@ -249,6 +305,6 @@ To run the tests in Chrome:
     $ npm install
     $ npm run test-browser
 
-### License
+## License
 
 [MIT](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
I personally find the current format a little hard to read, so I tried to make that better.

Before: https://github.com/mjackson/expect/blob/v1.11.1/README.md
After: https://github.com/mjackson/expect/blob/chore/reformat-readme/README.md

![pasted_image_9_27_15__2_54_pm](https://cloud.githubusercontent.com/assets/74385/10121610/9a363acc-6527-11e5-8339-f123dcdc3584.png)

I made the headings shorter to make it easier to digest:

![pasted_image_9_27_15__2_55_pm](https://cloud.githubusercontent.com/assets/74385/10121617/c22541c2-6527-11e5-83c1-b8d13b707c52.png)