### PR TITLE
Added documentation for spy expectations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,36 @@ expect('hello world').toExclude('goodbye')
 expect('hello world').toNotContain('goodbye')
 ```
 
+### (spy) toHaveBeenCalled
+
+> `expect(spy).toHaveBeenCalled([message])`
+
+Asserts the given `spy` function has been called at least once.
+
+```js
+expect(spy).toHaveBeenCalled()
+```
+
+### (spy) toNotHaveBeenCalled
+
+> `expect(spy).toNotHaveBeenCalled([message])`
+
+Asserts the given `spy` function has *not* been called.
+
+```js
+expect(spy).toNotHaveBeenCalled()
+```
+
+### (spy) toHaveBeenCalledWith
+
+> `expect(spy).toHaveBeenCalledWith(...args)`
+
+Asserts the given `spy` function has been called with the expected arguments.
+
+```js
+expect(spy).toHaveBeenCalledWith('foo', 'bar')
+```
+
 ## Chaining Assertions
 
 Every assertion returns an `Expectation` object, so you can chain assertions together.


### PR DESCRIPTION
There are examples of `toHaveBeenCalled` and `toHaveBeenCalledWith` in the Spies section, but I had to look at the source code to find out there's a `toNotHaveBeenCalled` method as well. This might save someone a few minutes :)