### PR TITLE
Just formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Asserts the given `object` is truthy.
 expect('something truthy').toExist()
 ```
 
-#### toNotExist
+### toNotExist
 
 > `expect(object).toNotExist([message])`
 


### PR DESCRIPTION
One too many hash signs made this section heading smaller than its peers.