### PR TITLE
return "this" in the expect.extend example

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ expect.extend({
       'expected %s to be an HTML color',
       this.actual
     )
+    return this
   }
 })
 


### PR DESCRIPTION
### Purpose
Improve documentation.

Copying the `expect.extends` example and attempting to 
chain other assertions after `toBeAColor` results in an error.

### Example 
```js
expect('#333333')
  .toBeAColor()
  .toBeA('string')
```
would not pass tests using the example on `master`

I think the example could be improved by ensuring that users who copy the snippet and modify it is able to chain other assertions after it.

Feel free to modify PR title/body

##### References
- Own experience
- [Expectation.js#L37](https://github.com/mjackson/expect/blob/master/modules/Expectation.js#L37)