### PR TITLE
Minor syntax highlighting fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ it('works', function () {
 
 Makes the spy invoke a function `fn` when called.
 
-```
+```js
 var dice = createSpy().andCall(function () {
   return (Math.random() * 6) | 0
 })


### PR DESCRIPTION
Add missing `js` to code-block for syntax highlighting.