### PR TITLE
Modify the object version of toInclude

### DIFF
--- a/modules/TestUtils.js
+++ b/modules/TestUtils.js
@@ -21,13 +21,6 @@ export const isObject = (object) =>
   object && !isArray(object) && typeof object === 'object'
 
 /**
- * Returns true if the given object is an empty object.
- */
-export const isEmptyObject = (object) =>
-  isObject(object)
-  && ownKeys(object).length === 0
-
-/**
  * Returns true if the given object is an instanceof value
  * or its typeof is the given value.
  */
@@ -95,11 +88,8 @@ export const objectContains = (object, value, compareValues) => {
   if (compareValues == null)
     compareValues = isEqual
 
-  if (isEmptyObject(value))
-    return true
-
   return ownKeys(value).every(k => {
-    if (isObject(object[k]) && !isEmptyObject(value[k])) {
+    if (isObject(object[k]) && isObject(value[k])) {
       return objectContains(object[k], value[k], compareValues)
     }
 

--- a/modules/TestUtils.js
+++ b/modules/TestUtils.js
@@ -1,5 +1,6 @@
 import isEqual from 'is-equal'
 import isRegExp from 'is-regex'
+import ownKeys from './ownKeys'
 
 /**
  * Returns true if the given object is a function.
@@ -18,6 +19,13 @@ export const isArray = (object) =>
  */
 export const isObject = (object) =>
   object && !isArray(object) && typeof object === 'object'
+
+/**
+ * Returns true if the given object is an empty object.
+ */
+export const isEmptyObject = (object) =>
+  isObject(object)
+  && ownKeys(object).length === 0
 
 /**
  * Returns true if the given object is an instanceof value
@@ -87,8 +95,11 @@ export const objectContains = (object, value, compareValues) => {
   if (compareValues == null)
     compareValues = isEqual
 
-  return Object.keys(value).every(k => {
-    if (isObject(object[k])) {
+  if (isEmptyObject(value))
+    return true
+
+  return ownKeys(value).every(k => {
+    if (isObject(object[k]) && !isEmptyObject(value[k])) {
       return objectContains(object[k], value[k], compareValues)
     }
 

--- a/modules/__tests__/toInclude-test.js
+++ b/modules/__tests__/toInclude-test.js
@@ -38,10 +38,6 @@ describe('toInclude', () => {
     expect(() => {
       expect({ a: 1, b: 2, c: 3 }).toInclude({ b: 4 })
     }).toThrow(/to include/)
-
-    expect(() => {
-      expect({ a: { b: 2 } }).toInclude({ a: {} })
-    }).toThrow(/to include/)
   })
 
   it('does not throw when an object contains an expected object in a deep key', () => {
@@ -64,6 +60,27 @@ describe('toInclude', () => {
     }).toThrow(/to include/)
   })
 
+  it('compares partial object only when both expected and actual properties are object', () => {
+    expect(() => {
+      expect({ a: { b: 2 } }).toInclude({ a: {} })
+    }).toNotThrow()
+
+    expect(() => {
+      expect({ a: 1 }).toInclude({ a: {} })
+    }).toThrow(/to include/)
+
+    expect(() => {
+      expect({ a: [] }).toInclude({ a: {} })
+    }).toThrow(/to include/)
+
+    expect(() => {
+      expect({ a: '1' }).toInclude({ a: {} })
+    }).toThrow(/to include/)
+
+    expect(() => {
+      expect({ a: () => {} }).toInclude({ a: {} })
+    }).toThrow(/to include/)
+  })
 
   if (typeof Object.create === 'function') {
     it('ignores nonenumerable properties of an expected object', () => {

--- a/modules/__tests__/toInclude-test.js
+++ b/modules/__tests__/toInclude-test.js
@@ -24,6 +24,10 @@ describe('toInclude', () => {
     expect(() => {
       expect({ a: 1, b: 2, c: 3 }).toInclude({ b: 2 })
     }).toNotThrow()
+
+    expect(() => {
+      expect({ a: 1, b: 2 }).toInclude({})
+    }).toNotThrow()
   })
 
   it('throws when an object does not contain an expected object', () => {
@@ -33,6 +37,10 @@ describe('toInclude', () => {
 
     expect(() => {
       expect({ a: 1, b: 2, c: 3 }).toInclude({ b: 4 })
+    }).toThrow(/to include/)
+
+    expect(() => {
+      expect({ a: { b: 2 } }).toInclude({ a: {} })
     }).toThrow(/to include/)
   })
 
@@ -55,6 +63,31 @@ describe('toInclude', () => {
       )
     }).toThrow(/to include/)
   })
+
+
+  if (typeof Object.create === 'function') {
+    it('ignores nonenumerable properties of an expected object', () => {
+      expect(() => {
+        expect({}).toInclude(Object.create({}, { a: { value: 1 } }))
+      }).toNotThrow()
+    })
+  }
+
+  if (typeof Symbol === 'function') {
+    const symbol = Symbol()
+
+    it('does not throw when an object contains an expected object with a symbol key', () => {
+      expect(() => {
+        expect({ [symbol]: 1, b: 2 }).toInclude({ [symbol]: 1 })
+      }).toNotThrow()
+    })
+
+    it('throws when an object contain an expected object without a symbol key', () => {
+      expect(() => {
+        expect({ a: 1, b: 2 }).toInclude({ [symbol]: 1 })
+      }).toThrow(/to include/)
+    })
+  }
 
   it('throws when an array does not contain an expected integer', () => {
     expect(() => {

--- a/modules/ownKeys.js
+++ b/modules/ownKeys.js
@@ -1,0 +1,19 @@
+import objectKeys from 'object-keys'
+
+const ownKeys = (object) => {
+  if (typeof Reflect === 'object' && typeof Reflect.ownKeys === 'function') {
+    return Reflect.ownKeys(object)
+      .filter(key => Object.getOwnPropertyDescriptor(object, key).enumerable)
+  }
+
+  if (typeof Object.getOwnPropertySymbols === 'function') {
+    return Object.getOwnPropertySymbols(object)
+      .filter(key => Object.getOwnPropertyDescriptor(object, key).enumerable)
+      .concat(objectKeys(object))
+  }
+
+  return objectKeys(object)
+}
+
+
+export default ownKeys

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "is-equal": "^1.5.1",
     "is-regex": "^1.0.3",
-    "object-inspect": "^1.1.0"
+    "object-inspect": "^1.1.0",
+    "object-keys": "^1.0.9"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
This PR introduces following changes:

* Traverse both enumerable  name keys and enumerable  symbol keys.

  `expect({a: 1}).toInclude({[Symbol()]: 1}) // fail`

* Always pass a assertion with an empty object as an expected value.

  `expect({a: 1}).toInclude({}) // pass`

BREAKING CHANGE: compare an empty object property to its corresponding actual property.

  Before:
    `expect({}).toInclude({a: {}}) // pass`

  After:
    `expect({a: 1}).toInclude({a: {}}) // fail`

Closes #82