### PR TITLE
spies preserve length of original function

### DIFF
--- a/modules/SpyUtils.js
+++ b/modules/SpyUtils.js
@@ -1,8 +1,12 @@
 /* eslint-disable prefer-rest-params */
+import { supportsDescriptors } from 'define-properties'
 import assert from './assert'
 import { isFunction } from './TestUtils'
 
 const noop = () => {}
+
+const supportsConfigurableFnLength = supportsDescriptors &&
+  Object.getOwnPropertyDescriptor(() => {}, 'length').configurable
 
 export const isSpy = (object) =>
   object && object.__isSpy === true
@@ -25,13 +29,9 @@ export const createSpy = (fn, restore = noop) => {
     'createSpy needs a function'
   )
 
-  let targetFn, thrownValue, returnValue
+  let targetFn, thrownValue, returnValue, spy
 
-  const spy = new Function('spy', `return function(${ // eslint-disable-line no-new-func
-    Array(...Array(fn.length)).map((_, i) => Array(i + 2).join('_')).join(',')
-  }) {
-    return spy.apply(this, arguments)
-  }`)(function () {
+  function spyLogic() {
     spy.calls.push({
       context: this,
       arguments: Array.prototype.slice.call(arguments, 0)
@@ -44,7 +44,18 @@ export const createSpy = (fn, restore = noop) => {
       throw thrownValue
 
     return returnValue
-  })
+  }
+
+  if (supportsConfigurableFnLength) {
+    spy = Object.defineProperty(spyLogic, 'length',
+      { value: fn.length, writable: false, enumerable: false, configurable: true })
+  } else {
+    spy = new Function('spy', `return function(${ // eslint-disable-line no-new-func
+      Array(...Array(fn.length)).map((_, i) => Array(i + 2).join('_')).join(',')
+    }) {
+      return spy.apply(this, arguments)
+    }`)(spyLogic)
+  }
 
   spy.calls = []
 

--- a/modules/SpyUtils.js
+++ b/modules/SpyUtils.js
@@ -27,7 +27,11 @@ export const createSpy = (fn, restore = noop) => {
 
   let targetFn, thrownValue, returnValue
 
-  const spy = function spy() {
+  const spy = new Function('spy', `return function(${ // eslint-disable-line no-new-func
+    Array(...Array(fn.length)).map((_, i) => Array(i + 2).join('_')).join(',')
+  }) {
+    return spy.apply(this, arguments)
+  }`)(function () {
     spy.calls.push({
       context: this,
       arguments: Array.prototype.slice.call(arguments, 0)
@@ -40,7 +44,7 @@ export const createSpy = (fn, restore = noop) => {
       throw thrownValue
 
     return returnValue
-  }
+  })
 
   spy.calls = []
 

--- a/modules/SpyUtils.js
+++ b/modules/SpyUtils.js
@@ -51,7 +51,7 @@ export const createSpy = (fn, restore = noop) => {
       { value: fn.length, writable: false, enumerable: false, configurable: true })
   } else {
     spy = new Function('spy', `return function(${ // eslint-disable-line no-new-func
-      Array(...Array(fn.length)).map((_, i) => Array(i + 2).join('_')).join(',')
+      [ ...Array(fn.length) ].map((_, i) => `_${i}`).join(',')
     }) {
       return spy.apply(this, arguments)
     }`)(spyLogic)

--- a/modules/__tests__/createSpy-test.js
+++ b/modules/__tests__/createSpy-test.js
@@ -37,6 +37,12 @@ describe('A spy', () => {
     expect(isSpy(spy)).toBe(true)
   })
 
+  it('has the same length as the function passed in', () => {
+    expect(spy.length).toBe(0)
+    expect(createSpy(a => a).length).toBe(1)
+    expect(createSpy((a, b, c) => a * b * c).length).toBe(3)
+  })
+
   it('has a destroy method', () => {
     expect(spy.destroy).toBeA(Function)
   })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
+    "define-properties": "~1.1.2",
     "has": "^1.0.1",
     "is-equal": "^1.5.1",
     "is-regex": "^1.0.3",


### PR DESCRIPTION
For testing libraries like `react-redux` or `react-refetch` that have different behaviours depending on the `length` of the function passed in, it is really useful that spies preserve the `length` of the function they're spying on.
(I tried to add this changing as little code as possible.)