### PR TITLE
Handle non-array keys in toIncludeKeys

### DIFF
--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -2,7 +2,6 @@ import isEqual from 'is-equal'
 import isRegExp from 'is-regex'
 import tmatch from 'tmatch'
 import has from 'has'
-import inspect from 'object-inspect'
 import assert from './assert'
 import { isSpy } from './SpyUtils'
 import {
@@ -399,13 +398,13 @@ class Expectation {
     assert(
       typeof this.actual === 'object',
       'The "actual" argument in expect(actual).toIncludeKeys() must be an object, not %s',
-      inspect(this.actual)
+      this.actual
     )
 
     assert(
       isArray(keys),
       'The "keys" argument in expect(actual).toIncludeKeys(keys) must be an array, not %s',
-      inspect(keys)
+      keys
     )
 
     const contains = keys.every(key => comparator(this.actual, key))
@@ -436,13 +435,13 @@ class Expectation {
     assert(
       typeof this.actual === 'object',
       'The "actual" argument in expect(actual).toExcludeKeys() must be an object, not %s',
-      inspect(this.actual)
+      this.actual
     )
 
     assert(
       isArray(keys),
       'The "keys" argument in expect(actual).toIncludeKeys(keys) must be an array, not %s',
-      inspect(keys)
+      keys
     )
 
     const contains = keys.every(key => comparator(this.actual, key))

--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -436,7 +436,13 @@ class Expectation {
     assert(
       typeof this.actual === 'object',
       'The "actual" argument in expect(actual).toExcludeKeys() must be an object, not %s',
-      typeof this.actual
+      inspect(this.actual)
+    )
+
+    assert(
+      isArray(keys),
+      'The "keys" argument in expect(actual).toIncludeKeys(keys) must be an array, not %s',
+      inspect(keys)
     )
 
     const contains = keys.every(key => comparator(this.actual, key))

--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -2,6 +2,7 @@ import isEqual from 'is-equal'
 import isRegExp from 'is-regex'
 import tmatch from 'tmatch'
 import has from 'has'
+import inspect from 'object-inspect'
 import assert from './assert'
 import { isSpy } from './SpyUtils'
 import {
@@ -398,7 +399,13 @@ class Expectation {
     assert(
       typeof this.actual === 'object',
       'The "actual" argument in expect(actual).toIncludeKeys() must be an object, not %s',
-      typeof this.actual
+      inspect(this.actual)
+    )
+
+    assert(
+      isArray(keys),
+      'The "keys" argument in expect(actual).toIncludeKeys(keys) must be an array, not %s',
+      inspect(keys)
     )
 
     const contains = keys.every(key => comparator(this.actual, key))

--- a/modules/__tests__/toExcludeKeys-test.js
+++ b/modules/__tests__/toExcludeKeys-test.js
@@ -7,6 +7,12 @@ describe('toExcludeKeys', () => {
     }).toThrow(/must be an object/)
   })
 
+  it('requires the keys to be an array', () => {
+    expect(() => {
+      expect({ a: 1 }).toIncludeKeys({ b: 2 })
+    }).toThrow(/must be an array/)
+  })
+
   it('throws when there is a key that exists', () => {
     expect(() => {
       expect({ a: 1 }).toExcludeKeys([ 'a' ])

--- a/modules/__tests__/toIncludeKeys-test.js
+++ b/modules/__tests__/toIncludeKeys-test.js
@@ -7,6 +7,12 @@ describe('toIncludeKeys', () => {
     }).toThrow(/must be an object/)
   })
 
+  it('requires the keys to be an array', () => {
+    expect(() => {
+      expect({ a: 1 }).toIncludeKeys({ b: 2 })
+    }).toThrow(/must be an array/)
+  })
+
   it('does not throw when there is a key that exists', () => {
     expect(() => {
       expect({ a: 1 }).toIncludeKeys([ 'a' ])


### PR DESCRIPTION
Throw a better error message when `toIncludeKeys` and `toExcludeKeys` are invoked with a non-array `keys`.

Before:

```
TypeError: keys.every is not a function
```

After:

```
Error: The "keys" argument in expect(actual).toIncludeKeys(keys) must be an array, not 'object'
```
