### PR TITLE
Typo in `toNotBeA` assertion; missing word 'not'

### DIFF
--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -159,7 +159,7 @@ class Expectation {
 
     assert(
       !isA(this.actual, value),
-      (message || 'Expected %s to be a %s'),
+      (message || 'Expected %s to not be a %s'),
       this.actual,
       value
     )


### PR DESCRIPTION
The word 'not' is missing from the `toNotBeA` expectation failure message which results in confusion.