### PR TITLE
add toHaveBeenCalledMatching expectation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 ## [HEAD]
-
+- Breaking change: `toHaveBeenCalledWith` now uses tmatch instead of isEqual,
+  which gives an ability to write more flexible assertions ([#141])
 - `toMatch` and `toNotMatch` use `tmatch` directly, so a wider array
   of objects and patterns are supported
 
 [HEAD]: https://github.com/mjackson/expect/compare/v1.20.1...HEAD
+[#141]: https://github.com/mjackson/expect/pull/141
 
 ## [v1.20.1]
 > May 7, 2016

--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -440,7 +440,7 @@ class Expectation {
     )
 
     assert(
-      spy.calls.some(call => isEqual(call.arguments, expectedArgs)),
+      spy.calls.some(call => tmatch(call.arguments, expectedArgs)),
       'spy was never called with %s',
       expectedArgs
     )

--- a/modules/__tests__/toHaveBeenCalledWith-test.js
+++ b/modules/__tests__/toHaveBeenCalledWith-test.js
@@ -1,0 +1,45 @@
+import expect, { createSpy } from '../index'
+
+describe('toHaveBeenCalledWith', () => {
+  it('accepts exaclty equal arguments', () => {
+    const spy = createSpy()
+    spy('test')
+    spy('two', 'arguments')
+
+    expect(spy).toHaveBeenCalledWith('test')
+    expect(spy).toHaveBeenCalledWith('two', 'arguments')
+  })
+
+  it('accepts matching arguments', () => {
+    const spy = createSpy()
+    spy(1, 'first call')
+    spy(2, 'second call')
+
+    expect(spy).toHaveBeenCalledWith(1, /call/)
+    expect(spy).toHaveBeenCalledWith(2, /call/)
+  })
+
+  it('makes type matching if constructor function is provided', () => {
+    expect(() => {
+      const spy = createSpy()
+      spy(() => {})
+      expect(spy).toHaveBeenCalledWith(Function)
+    }).toNotThrow()
+
+    expect(() => {
+      const spy = createSpy()
+      spy([])
+      expect(spy).toHaveBeenCalledWith(Array)
+    }).toNotThrow()
+  })
+
+  it('throws on not matching arguments', () => {
+    const spy = createSpy()
+    spy([])
+    spy('test')
+
+    expect(() => {
+      expect(spy).toHaveBeenCalledWith(false)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #107 
I'd like to create a new expectation rather than modify existing `toHaveBeenCalledWith`, because `tmatch` matches `1` and `'1'` as equal, which can break tests for some users.
