### PR TITLE
Add expect.spyOnRewired helper for unit testing es6 modules with babel-plugin-rewire

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,14 @@
 {
   "presets": [
     "es2015"
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        [
+          "babel-plugin-rewire"
+        ]
+      ]
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ spy.restore()
 ### spyOnRewired
 
 If you happen to be using babel, and have the [babel-rewire-plugin](https://github.com/speedskater/babel-plugin-rewire)
-installed, you can use spyOnRewired yo spy on functions within a rewired module.
+installed, you can use spyOnRewired to spy on top-level functions within a rewired module.
 
 > `expect.spyOnRewired(rewiredModule, method)`
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,36 @@ video.play()
 spy.restore()
 ```
 
+### spyOnRewired
+
+If you happen to be using babel, and have the [babel-rewire-plugin](https://github.com/speedskater/babel-plugin-rewire)
+installed, you can use spyOnRewired yo spy on functions within a rewired module.
+
+> `expect.spyOnRewired(rewiredModule, method)`
+
+Replaces/rewires the `method` in `rewiredModule` with a spy.
+
+```js
+// foo.js example
+export function barCalledByFoo(a, b) {
+  return "bar " + a + " " + b
+}
+
+export function foo(a, b) {
+  return "foo" + barCalledByFoo(a, b)
+}
+
+// foo-mocha-test.js example
+import { foo, barCalledByFoo, __RewireAPI__ as rewiredModule } from './foo'
+
+var spy = expect.spyOnRewired(rewiredModule, 'barCalledByFoo')
+foo('it', 'works');
+expect(spy.calls.length).toEqual(1)
+expect(spy.calls[0].arguments).toEqual([ 'it', 'works' ])
+
+spy.restore()
+```
+
 ### restoreSpies
 
 > `expect.restoreSpies()`

--- a/modules/SpyUtils.js
+++ b/modules/SpyUtils.js
@@ -53,6 +53,7 @@ export const createSpy = (fn, restore = noop) => {
     spy = new Function('spy', `return function(${ // eslint-disable-line no-new-func
       [ ...Array(fn.length) ].map((_, i) => `_${i}`).join(',')
     }) {
+      "use strict";
       return spy.apply(this, arguments)
     }`)(spyLogic)
   }

--- a/modules/SpyUtils.js
+++ b/modules/SpyUtils.js
@@ -110,3 +110,27 @@ export const spyOn = (object, methodName) => {
 
   return object[methodName]
 }
+
+export const spyOnRewired = (rewiredModule, dependencyName) => {
+  const original = rewiredModule.__get__(dependencyName)
+
+  if (!isSpy(original)) {
+    assert(
+      isFunction(original),
+      'Cannot spyOnRewired the %s dependency; it is not a function',
+      dependencyName
+    )
+
+    let unrewire
+
+    let spy = createSpy(original, () => {
+      unrewire()
+    })
+
+    unrewire = rewiredModule.__set__(dependencyName, spy)
+
+    return spy
+  }
+
+  return original
+}

--- a/modules/__tests__/spyOnRewired-module.js
+++ b/modules/__tests__/spyOnRewired-module.js
@@ -1,0 +1,7 @@
+export function barCalledByFoo(a, b) { // eslint-disable-line no-unused-vars
+  return "bar"
+}
+
+export function foo(a, b) {
+  return "foo" + barCalledByFoo(a, b)
+}

--- a/modules/__tests__/spyOnRewired-test.js
+++ b/modules/__tests__/spyOnRewired-test.js
@@ -1,0 +1,62 @@
+import expect, { spyOnRewired } from '../index'
+
+/*eslint-disable no-unused-vars, import/named */
+import { foo, barCalledByFoo, __RewireAPI__ as rewiredModule } from './spyOnRewired-module'
+/*eslint-enable no-unused-vars, import/named */
+
+describe('A rewired function that was spied on', () => {
+  let spy
+  beforeEach(() => {
+    spy = spyOnRewired(rewiredModule, 'barCalledByFoo')
+    foo('some', 'args')
+  })
+
+  it('tracks the number of calls', () => {
+    expect(spy.calls.length).toEqual(1)
+  })
+
+  it('tracks the context that was used', () => {
+    expect(spy.calls[0].context).toBe(undefined)
+  })
+
+  it('tracks the arguments that were used', () => {
+    expect(spy.calls[0].arguments).toEqual([ 'some', 'args' ])
+  })
+
+  it('was called', () => {
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('was called with the correct args', () => {
+    expect(spy).toHaveBeenCalledWith('some', 'args')
+  })
+
+  it('can be restored', () => {
+    expect(rewiredModule.__get__('barCalledByFoo')).toEqual(spy)
+    spy.restore()
+    expect(rewiredModule.__get__('barCalledByFoo')).toNotEqual(spy)
+  })
+
+  after(() => {
+    spy.restore()
+  })
+})
+
+describe('A rewired function that was spied on but not called', () => {
+  let spy
+  beforeEach(() => {
+    spy = spyOnRewired(rewiredModule, 'barCalledByFoo')
+  })
+
+  it('number of calls to be zero', () => {
+    expect(spy.calls.length).toEqual(0)
+  })
+
+  it('was not called', () => {
+    expect(spy).toNotHaveBeenCalled()
+  })
+
+  after(() => {
+    spy.restore()
+  })
+})

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,5 +1,5 @@
 import Expectation from './Expectation'
-import { createSpy, spyOn, isSpy, restoreSpies } from './SpyUtils'
+import { createSpy, spyOn, spyOnRewired, isSpy, restoreSpies } from './SpyUtils'
 import assert from './assert'
 import extend from './extend'
 
@@ -9,6 +9,7 @@ function expect(actual) {
 
 expect.createSpy = createSpy
 expect.spyOn = spyOn
+expect.spyOnRewired = spyOnRewired
 expect.isSpy = isSpy
 expect.restoreSpies = restoreSpies
 expect.assert = assert

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-umd": "webpack modules/index.js umd/expect.js",
     "build-min": "webpack -p modules/index.js umd/expect.min.js",
     "lint": "eslint modules",
-    "test": "npm run lint && karma start",
+    "test": "npm run lint && BABEL_ENV=test karma start",
     "release": "node ./scripts/release.js",
     "prepublish": "node ./scripts/build.js"
   },
@@ -33,6 +33,7 @@
     "babel-cli": "^6.6.5",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.4",
+    "babel-plugin-rewire": "^1.0.0",
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^3.2.2",
     "eslint-plugin-import": "^1.12.0",


### PR DESCRIPTION
I use babel-plugin-rewire to get around spying/mocking top-level es6 module functions.

I often wish I could use something like expect.spyOn for the task, but unfortunately the rewire syntax is not quite compatible, so this PR bridges that gap.