### PR TITLE
Add ability to ignore arguments in toHaveBeenCalledWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ Asserts the given `spy` function has been called with the expected arguments.
 expect(spy).toHaveBeenCalledWith('foo', 'bar')
 ```
 
+Pass `expect.ANY` for parameters that should be ignored.
+
+```js
+expect(spy).toHaveBeenCalledWith('foo', expect.ANY, 'bar')
+```
+
 ## Chaining Assertions
 
 Every assertion returns an `Expectation` object, so you can chain assertions together.

--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -440,7 +440,8 @@ class Expectation {
     )
 
     assert(
-      spy.calls.some(call => [].slice.call(call.arguments).every( (argument, index) => isEqual(argument, expectedArgs[index]))),
+      spy.calls.some(call => call.arguments.length === expectedArgs.length &&
+            [].slice.call(call.arguments).every( (argument, index) => isEqual(argument, expectedArgs[index]))),
       'spy was never called with %s',
       expectedArgs
     )

--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -440,7 +440,7 @@ class Expectation {
     )
 
     assert(
-      spy.calls.some(call => isEqual(call.arguments, expectedArgs)),
+      spy.calls.some(call => Array.from(call.arguments).every( (argument, index) => isEqual(argument, expectedArgs[index]))),
       'spy was never called with %s',
       expectedArgs
     )

--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -440,7 +440,7 @@ class Expectation {
     )
 
     assert(
-      spy.calls.some(call => Array.from(call.arguments).every( (argument, index) => isEqual(argument, expectedArgs[index]))),
+      spy.calls.some(call => [].slice.call(call.arguments).every( (argument, index) => isEqual(argument, expectedArgs[index]))),
       'spy was never called with %s',
       expectedArgs
     )

--- a/modules/TestUtils.js
+++ b/modules/TestUtils.js
@@ -1,13 +1,14 @@
 import isRegExp from 'is-regex'
 import whyNotStrictlyEqual from 'is-equal/why'
 import objectKeys from 'object-keys'
+import { ANY } from './assert'
 
 /**
  * Returns the reason why the given arguments are not *conceptually*
  * equal, if any; the empty string otherwise.
  */
 export const whyNotEqual = (a, b) =>
-  (a == b ? '' : whyNotStrictlyEqual(a, b)) // eslint-disable-line eqeqeq
+  ((a == b || b === ANY) ? '' : whyNotStrictlyEqual(a, b)) // eslint-disable-line eqeqeq
 
 /**
  * Returns true if the given arguments are *conceptually* equal.

--- a/modules/__tests__/spyOn-test.js
+++ b/modules/__tests__/spyOn-test.js
@@ -1,4 +1,4 @@
-import expect, { spyOn } from '../index'
+import expect, { spyOn, ANY } from '../index'
 
 describe('A function that was spied on', () => {
   const video = {
@@ -29,6 +29,45 @@ describe('A function that was spied on', () => {
 
   it('was called with the correct args', () => {
     expect(spy).toHaveBeenCalledWith('some', 'args')
+  })
+
+  it('was called once with the correct args', () => {
+    video.play('other', 'args')
+    expect(spy).toHaveBeenCalledWith('some', 'args')
+    expect(spy).toHaveBeenCalledWith('other', 'args')
+  })
+
+  it('was called once with no args', () => {
+    video.play()
+    expect(spy).toHaveBeenCalledWith()
+  })
+
+  it('rejects a bad arg', () => {
+    try {
+      expect(spy).toHaveBeenCalledWith('some', 'wrong')
+    } catch (err) {
+      expect(err.message).toMatch('spy was never called with')
+    }
+  })
+
+  it('rejects missing args', () => {
+    try {
+      expect(spy).toHaveBeenCalledWith()
+    } catch (err) {
+      expect(err.message).toMatch('spy was never called with')
+    }
+  })
+
+  it('was called with an ignored arg', () => {
+    expect(spy).toHaveBeenCalledWith('some', ANY)
+  })
+
+  it('rejects a faked ANY arg', () => {
+    try {
+      expect(spy).toHaveBeenCalledWith('some', {})
+    } catch (err) {
+      expect(err.message).toMatch('spy was never called with')
+    }
   })
 
   it('can be restored', () => {

--- a/modules/__tests__/spyOn-test.js
+++ b/modules/__tests__/spyOn-test.js
@@ -62,6 +62,27 @@ describe('A function that was spied on', () => {
     expect(spy).toHaveBeenCalledWith('some', ANY)
   })
 
+  it('handles fewer expected args', () => {
+    try {
+      expect(spy).toHaveBeenCalledWith('some')
+    } catch (err) {
+      expect(err.message).toMatch('spy was never called with')
+    }
+  })
+
+  it('handles too many expected args', () => {
+    try {
+      expect(spy).toHaveBeenCalledWith('some', 'args', ANY)
+    } catch (err) {
+      expect(err.message).toMatch('spy was never called with')
+    }
+    try {
+      expect(spy).toHaveBeenCalledWith('some', 'args', 'more')
+    } catch (err) {
+      expect(err.message).toMatch('spy was never called with')
+    }
+  })
+
   it('rejects a faked ANY arg', () => {
     try {
       expect(spy).toHaveBeenCalledWith('some', {})

--- a/modules/__tests__/spyOn-test.js
+++ b/modules/__tests__/spyOn-test.js
@@ -1,12 +1,12 @@
 import expect, { spyOn, ANY } from '../index'
 
 describe('A function that was spied on', () => {
-  const video = {
-    play: () => {}
-  }
+  let spy, video
 
-  let spy
   beforeEach(() => {
+    video = {
+      play: () => {}
+    }
     spy = spyOn(video, 'play')
     video.play('some', 'args')
   })
@@ -42,20 +42,12 @@ describe('A function that was spied on', () => {
     expect(spy).toHaveBeenCalledWith()
   })
 
-  it('rejects a bad arg', () => {
-    try {
-      expect(spy).toHaveBeenCalledWith('some', 'wrong')
-    } catch (err) {
-      expect(err.message).toMatch('spy was never called with')
-    }
+  it('rejects missing args', () => {
+    expect(() => { expect(spy).toHaveBeenCalledWith() }).toThrow('spy was never called with')
   })
 
-  it('rejects missing args', () => {
-    try {
-      expect(spy).toHaveBeenCalledWith()
-    } catch (err) {
-      expect(err.message).toMatch('spy was never called with')
-    }
+  it('rejects a bad arg', () => {
+    expect(() => { expect(spy).toHaveBeenCalledWith('some', 'wrong') }).toThrow('spy was never called with')
   })
 
   it('was called with an ignored arg', () => {
@@ -63,32 +55,16 @@ describe('A function that was spied on', () => {
   })
 
   it('handles fewer expected args', () => {
-    try {
-      expect(spy).toHaveBeenCalledWith('some')
-    } catch (err) {
-      expect(err.message).toMatch('spy was never called with')
-    }
+    expect(() => { expect(spy).toHaveBeenCalledWith('some') }).toThrow('spy was never called with')
   })
 
   it('handles too many expected args', () => {
-    try {
-      expect(spy).toHaveBeenCalledWith('some', 'args', ANY)
-    } catch (err) {
-      expect(err.message).toMatch('spy was never called with')
-    }
-    try {
-      expect(spy).toHaveBeenCalledWith('some', 'args', 'more')
-    } catch (err) {
-      expect(err.message).toMatch('spy was never called with')
-    }
+    expect(() => { expect(spy).toHaveBeenCalledWith('some', 'args', ANY) }).toThrow('spy was never called with')
+    expect(() => { expect(spy).toHaveBeenCalledWith('some', 'args', 'more') }).toThrow('spy was never called with')
   })
 
   it('rejects a faked ANY arg', () => {
-    try {
-      expect(spy).toHaveBeenCalledWith('some', {})
-    } catch (err) {
-      expect(err.message).toMatch('spy was never called with')
-    }
+    expect(() => { expect(spy).toHaveBeenCalledWith('some', {}) }).toThrow('spy was never called with')
   })
 
   it('can be restored', () => {

--- a/modules/assert.js
+++ b/modules/assert.js
@@ -16,4 +16,6 @@ const assert = (condition, createMessage, ...extraArgs) => {
   throw new Error(message)
 }
 
+export const ANY = {}
+
 export default assert

--- a/modules/assert.js
+++ b/modules/assert.js
@@ -16,6 +16,9 @@ const assert = (condition, createMessage, ...extraArgs) => {
   throw new Error(message)
 }
 
-export const ANY = {}
+const anyClass = () => {}
+anyClass.prototype.toString = anyClass.prototype.inspect = () => 'ANY'
+const ANY = new anyClass()
+export { ANY }
 
 export default assert

--- a/modules/assert.js
+++ b/modules/assert.js
@@ -16,9 +16,11 @@ const assert = (condition, createMessage, ...extraArgs) => {
   throw new Error(message)
 }
 
-const anyClass = () => {}
-anyClass.prototype.toString = anyClass.prototype.inspect = () => 'ANY'
-const ANY = new anyClass()
+const ANY = { inspect() { return 'ANY' }, toString() { return 'ANY' } }
+if (Object.defineProperty) { Object.defineProperty(ANY, 'inspect', { enumerable: false }) }
+if (Object.defineProperty) { Object.defineProperty(ANY, 'toString', { enumerable: false }) }
+if (Object.setPrototypeOf) { Object.setPrototypeOf(ANY, null) }
+if (Object.freeze) { Object.freeze(ANY) }
 export { ANY }
 
 export default assert

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,6 +1,6 @@
 import Expectation from './Expectation'
 import { createSpy, spyOn, isSpy, restoreSpies } from './SpyUtils'
-import assert from './assert'
+import assert, { ANY } from './assert'
 import extend from './extend'
 
 function expect(actual) {
@@ -13,5 +13,6 @@ expect.isSpy = isSpy
 expect.restoreSpies = restoreSpies
 expect.assert = assert
 expect.extend = extend
+expect.ANY = ANY
 
 module.exports = expect


### PR DESCRIPTION
Added an 'ANY' constant that can be passed to toHaveBeenCalledWith to
cause it to ignore that argument, but compare the rest.