### PR TITLE
Add expect-enzyme extension to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,3 +553,4 @@ expect('#ff00ff').toBeAColor()
 - [expect-element](https://github.com/mjackson/expect-element) Adds assertions that are useful for DOM elements
 - [expect-jsx](https://github.com/algolia/expect-jsx) Adds things like `expect(ReactComponent).toEqualJSX(<TestComponent prop="yes" />)`
 - [expect-predicate](https://github.com/erikras/expect-predicate) Adds assertions based on arbitrary predicates
+- [expect-enzyme](https://github.com/PsychoLlama/expect-enzyme) Augments and extends expect to supercharge your enzyme assertions


### PR DESCRIPTION
Hey @mjackson! I made an `expect` extension for [enzyme](https://github.com/airbnb/enzyme) (a library for testing React components) and I'd like to shamelessly publicize it on your readme :smile:

> ps: I love your expect library! It's in nearly all my projects.