### PR TITLE
Fix small mistake in toNotMatch example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ expect({
 
 ### toNotMatch
 
-> `expect(string).toMatch(pattern, [message])`<br>
-> `expect(object).toMatch(pattern, [message])`
+> `expect(string).toNotMatch(pattern, [message])`<br>
+> `expect(object).toNotMatch(pattern, [message])`
 
 Asserts the given `string` or `object` does not match a `pattern`. When using a string, `pattern` must be a `RegExp`. When using an object, `pattern` may be anything acceptable to [`tmatch`](https://github.com/tapjs/tmatch).
 


### PR DESCRIPTION
Hello! I think there's a small mistake in your docs, so I've quickly made a fix. :)