### PR TITLE
Improve failure messages for toThrow, toNotThrow, and toHaveBeenCalledWith

### DIFF
--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -8,7 +8,8 @@ import {
   isArray,
   isEqual,
   isObject,
-  functionThrows,
+  catchThrown,
+  matchThrown,
   arrayContains,
   objectContains,
   stringContains
@@ -108,11 +109,20 @@ class Expectation {
       this.actual
     )
 
+    const thrown = catchThrown(this.actual, this.context, this.args)
+
     assert(
-      functionThrows(this.actual, this.context, this.args, value),
-      (message || 'Expected %s to throw %s'),
+      thrown !== null,
+      (message || 'Expected %s to throw an error'),
+      this.actual
+    )
+
+    assert(
+      matchThrown(thrown, value),
+      (message || 'Expected %s to throw %s. Actually threw %s'),
       this.actual,
-      value || 'an error'
+      value,
+      thrown.message
     )
 
     return this
@@ -125,12 +135,23 @@ class Expectation {
       this.actual
     )
 
-    assert(
-      !functionThrows(this.actual, this.context, this.args, value),
-      (message || 'Expected %s to not throw %s'),
-      this.actual,
-      value || 'an error'
-    )
+    const thrown = catchThrown(this.actual, this.context, this.args)
+
+    if (value) {
+      assert(
+        thrown == null || !matchThrown(thrown, value),
+        (message || 'Expected %s to not throw %s'),
+        this.actual,
+        value
+      )
+    } else {
+      assert(
+        thrown == null,
+        (message || 'Expected %s to not throw an error. Actually threw %s'),
+        this.actual,
+        thrown && thrown.message
+      )
+    }
 
     return this
   }

--- a/modules/Expectation.js
+++ b/modules/Expectation.js
@@ -461,9 +461,15 @@ class Expectation {
     )
 
     assert(
+      spy.calls.length > 0,
+      'spy was not called'
+    )
+
+    assert(
       spy.calls.some(call => isEqual(call.arguments, expectedArgs)),
-      'spy was never called with %s',
-      expectedArgs
+      'spy was not called with %s, but was called with %s',
+      expectedArgs,
+      spy.calls.map(call => call.arguments)
     )
 
     return this

--- a/modules/TestUtils.js
+++ b/modules/TestUtils.js
@@ -48,6 +48,19 @@ export const isA = (object, value) => {
 }
 
 /**
+ * Returns the thrown exception or null
+ */
+export const catchThrown = (fn, context, args) => {
+  try {
+    fn.apply(context, args)
+  } catch (error) {
+    return error
+  }
+
+  return null
+}
+
+/**
  * Returns true if the given function throws the given value
  * when invoked. The value may be:
  *
@@ -56,28 +69,22 @@ export const isA = (object, value) => {
  * - a regular expression, to compare with the error message
  * - a string, to find in the error message
  */
-export const functionThrows = (fn, context, args, value) => {
-  try {
-    fn.apply(context, args)
-  } catch (error) {
-    if (value == null)
+export const matchThrown = (error, value) => {
+  if (value == null)
+    return true
+
+  if (isFunction(value) && error instanceof value)
+    return true
+
+  const message = error.message || error
+
+  if (typeof message === 'string') {
+    if (isRegExp(value) && value.test(error.message))
       return true
 
-    if (isFunction(value) && error instanceof value)
+    if (typeof value === 'string' && message.indexOf(value) !== -1)
       return true
-
-    const message = error.message || error
-
-    if (typeof message === 'string') {
-      if (isRegExp(value) && value.test(error.message))
-        return true
-
-      if (typeof value === 'string' && message.indexOf(value) !== -1)
-        return true
-    }
   }
-
-  return false
 }
 
 /**

--- a/modules/__tests__/spyOn-test.js
+++ b/modules/__tests__/spyOn-test.js
@@ -23,18 +23,53 @@ describe('A function that was spied on', () => {
     expect(spy.calls[0].arguments).toEqual([ 'some', 'args' ])
   })
 
-  it('was called', () => {
-    expect(spy).toHaveBeenCalled()
-  })
-
-  it('was called with the correct args', () => {
-    expect(spy).toHaveBeenCalledWith('some', 'args')
-  })
-
   it('can be restored', () => {
     expect(video.play).toEqual(spy)
     spy.restore()
     expect(video.play).toNotEqual(spy)
+  })
+})
+
+describe('toHaveBeenCalled', () => {
+  let spy
+  beforeEach(() => {
+    spy = expect.createSpy()
+  })
+
+  it('does not throw when the spy was called', () => {
+    spy()
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('throws when the spy was not called', () => {
+    expect(()=>{
+      expect(spy).toHaveBeenCalled()
+    }).toThrow('spy was not called')
+  })
+})
+
+describe('toHaveBeenCalledWith', () => {
+  let spy
+  beforeEach(() => {
+    spy = expect.createSpy()
+  })
+
+  it('does not throw when the spy was called with those arguments', () => {
+    spy('some', 'args')
+    expect(spy).toHaveBeenCalledWith('some', 'args')
+  })
+
+  it('throws when the spy was not called', () => {
+    expect(()=>{
+      expect(spy).toHaveBeenCalledWith('some', 'args')
+    }).toThrow(/spy was not called/)
+  })
+
+  it('throws when the spy was called with other args', () => {
+    spy('other', 'args')
+    expect(()=>{
+      expect(spy).toHaveBeenCalledWith('some', 'args')
+    }).toThrow("spy was not called with [ 'some', 'args' ], but was called with [ [ 'other', 'args' ] ]")
   })
 })
 

--- a/modules/__tests__/toThrow-test.js
+++ b/modules/__tests__/toThrow-test.js
@@ -1,0 +1,65 @@
+import expect from '../index'
+
+describe('toThrow', () => {
+  it('does not throw when an exception was thrown', () => {
+    expect(()=>{
+      throw new Error("boom!")
+    }).toThrow()
+  })
+
+  it('throws when the an exception was not thrown', () => {
+    expect(()=>{
+      expect(()=>{}).toThrow()
+    }).toThrow('Expected [Function] to throw an error')
+  })
+
+  describe('with an expected message', () => {
+    it('does not throw when the message matches', () => {
+      expect(()=>{
+        throw new Error("boom!")
+      }).toThrow(/boom/)
+    })
+
+    it('throws when no exception was thrown', () => {
+      expect(()=>{
+        expect(()=>{}).toThrow(/boom/)
+      }).toThrow('Expected [Function] to throw an error')
+    })
+
+    it('throws when the message does not match', () => {
+      expect(()=>{
+        expect(()=>{
+          throw new Error("boom!")
+        }).toThrow(/bang/)
+      }).toThrow("Expected [Function] to throw /bang/. Actually threw 'boom!'")
+    })
+  })
+})
+
+describe('toNotThrow', () => {
+  it('throws when an exception was thrown', () => {
+    expect(()=>{
+      expect(()=>{ throw new Error("boom!") }).toNotThrow()
+    }).toThrow("Expected [Function] to not throw an error. Actually threw 'boom!'")
+  })
+
+  it('does not throw when an exception was not thrown', () => {
+    expect(()=>{}).toNotThrow()
+  })
+
+  describe('with an expected message', () => {
+    it('throws when the message matches', () => {
+      expect(()=>{
+        expect(()=>{ throw new Error("boom!") }).toNotThrow(/boom/)
+      }).toThrow('Expected [Function] to not throw /boom/')
+    })
+
+    it('does not throw when no exception was thrown', () => {
+      expect(()=>{}).toNotThrow(/boom/)
+    })
+
+    it('does not throw when the message does not match', () => {
+      expect(()=>{ throw new Error("boom!") }).toNotThrow(/bang/)
+    })
+  })
+})


### PR DESCRIPTION
Hello, I set out to improve the error messages for toHaveBeenCalledWith to be more specific in cases where the spy was never called at all, and to show call arguments in cases where it was called but not with the expected arguments. While trying to test-drive my changes I found the failures for toThrow similarly opaque, so I tried to improve those too.

I tried to be consistent with the existing testing style and message formats. Please let me know if there are changes you'd like to see, either in the general approach or specific implementation.

Thanks,
colin