### PR TITLE
update is-equal library

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "define-properties": "~1.1.2",
     "has": "^1.0.1",
-    "is-equal": "^1.5.1",
+    "is-equal": "^1.5.5",
     "is-regex": "^1.0.3",
     "object-inspect": "^1.1.0",
     "object-keys": "^1.0.9",


### PR DESCRIPTION
the library `is-equal` has some problems with objects compare, the yarn.lock was locking the old version in the dependencies.

Ref issue https://github.com/mjackson/expect/issues/194 
cc @ljharb