### PR TITLE
Escape `<` in unpkg URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var isSpy = expect.isSpy
 The UMD build is also available on [unpkg](https://unpkg.com):
 
 ```html
-<script src="https://unpkg.com/expect@<21/umd/expect.min.js"></script>
+<script src="https://unpkg.com/expect@%3C21/umd/expect.min.js"></script>
 ```
 
 You can find the library on `window.expect`.


### PR DESCRIPTION
Tools like codepen don't like that non-escaped URL. This converts the `<` to `%3C`

![screen shot 2017-12-12 at 7 31 01 am](https://user-images.githubusercontent.com/659829/33892804-9d41c9a8-df0e-11e7-96a5-2ef9d111cc01.png)
